### PR TITLE
Don't wrap an object more than once

### DIFF
--- a/ReflectionMagic/PrivateReflectionUsingDynamicExtensions.cs
+++ b/ReflectionMagic/PrivateReflectionUsingDynamicExtensions.cs
@@ -8,7 +8,7 @@ namespace ReflectionMagic
         public static dynamic AsDynamic(this object o)
         {
             // Don't wrap primitive types, which don't have many interesting internal APIs
-            if (o == null || o.GetType().IsPrimitive || o is string)
+            if (o == null || o.GetType().IsPrimitive || o is string || o is PrivateReflectionDynamicObjectBase)
                 return o;
 
             return new PrivateReflectionDynamicObjectInstance(o);


### PR DESCRIPTION
This makes the action .AsDynamic() idempotent, so x.AsDynamic().AsDynamic() can still access x's fields; this also means code which uses the AsDynamic() version can be reentrant.
