### PR TITLE
Reduce usage of LINQ in constructor selection

### DIFF
--- a/src/ReflectionMagic/PrivateReflectionDynamicObjectStatic.cs
+++ b/src/ReflectionMagic/PrivateReflectionDynamicObjectStatic.cs
@@ -45,24 +45,18 @@ namespace ReflectionMagic
 #if NETSTANDARD1_5
             var constructors = TargetType.GetTypeInfo().GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
-            var argumentTypes = new Type[args.Length];
-            for (int i = 0; i < args.Length; ++i)
-            {
-                argumentTypes[i] = args[i].GetType();
-            }
-
             object result = null;
             for (int i = 0; i < constructors.Length; ++i)
             {
                 var constructor = constructors[i];
                 var parameters = constructor.GetParameters();
 
-                if (parameters.Length == argumentTypes.Length)
+                if (parameters.Length == args.Length)
                 {
                     bool found = true;
-                    for (int j = 0; j < argumentTypes.Length; ++j)
+                    for (int j = 0; j < args.Length; ++j)
                     {
-                        if (parameters[j].ParameterType != argumentTypes[j])
+                        if (parameters[j].ParameterType != args[j].GetType())
                         {
                             found = false;
                             break;
@@ -78,7 +72,7 @@ namespace ReflectionMagic
             }
 
             if (result == null)
-                throw new MissingMethodException($"Constructor that accepts parameters: '{string.Join(", ", argumentTypes.Select(x => x.ToString()))}' not found.");
+                throw new MissingMethodException($"Constructor that accepts parameters: '{string.Join(", ", args.Select(x => x.GetType().ToString()))}' not found.");
 
             return result.AsDynamic();
 #else


### PR DESCRIPTION
The current implementation uses a LINQ based approach for selecting a constructor to work around the issue of not having the correct overload for Activator.CreateInstance() available.

This is allocating quite a bit of garbage and is not ideal as can be seen below:

``` ini

BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-7700K CPU 4.20GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.1.201
  [Host]     : .NET Core 1.1.8 (CoreCLR 4.6.26328.01, CoreFX 4.6.24705.01), 64bit RyuJIT
  DefaultJob : .NET Core 1.1.8 (CoreCLR 4.6.26328.01, CoreFX 4.6.24705.01), 64bit RyuJIT


```
|                  Method |         Mean |     Error |    StdDev |  Gen 0 | Allocated |
|------------------------ |-------------:|----------:|----------:|-------:|----------:|
| DirectConstructorNoArgs |     2.872 ns | 0.0048 ns | 0.0040 ns | 0.0172 |      72 B |
|          NoArgumentsOld | 1,631.505 ns | 2.1347 ns | 1.6666 ns | 0.3872 |    1624 B |
|          NoArgumentsNew |   281.524 ns | 0.2437 ns | 0.2280 ns | 0.0587 |     248 B |
|       SingleArgumentOld | 1,765.470 ns | 2.6305 ns | 2.4606 ns | 0.4101 |    1728 B |
|       SingleArgumentNew |   374.443 ns | 0.6819 ns | 0.5694 ns | 0.0782 |     328 B |
|         TwoArgumentsOld | 1,800.418 ns | 2.3833 ns | 2.2293 ns | 0.4177 |    1752 B |
|         TwoArgumentsNew |   460.282 ns | 0.2595 ns | 0.2427 ns | 0.0930 |     392 B |
|       EightArgumentsOld | 2,457.870 ns | 1.9476 ns | 1.8218 ns | 0.5226 |    2208 B |
|       EightArgumentsNew |   945.033 ns | 6.9714 ns | 5.8215 ns | 0.2222 |     936 B |

This represents a 200-600% increase of performance and a likewise reduction of allocations. Using reflection remains slow ofcourse.

Also fixes #19.