### PR TITLE
Set the backing field for _inherited_ get-only properties

### DIFF
--- a/src/ReflectionMagic/Property.cs
+++ b/src/ReflectionMagic/Property.cs
@@ -38,13 +38,16 @@ namespace ReflectionMagic
             else
             {
                 var backingFieldName = $"<{_propertyInfo.Name}>k__BackingField";
-                var type = obj.GetType();
-                var backingField = type.GetField(backingFieldName, BindingFlags.Instance | BindingFlags.NonPublic);
-                if (backingField == null)
+                for (var type = obj.GetType(); type != null; type = type.BaseType)
                 {
-                    throw new MissingMemberException($"The property {type}.{_propertyInfo.Name} does not have a setter nor a backing field ({backingFieldName}).");
+                    var backingField = type.GetField(backingFieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+                    if (backingField != null)
+                    {
+                        backingField.SetValue(obj, value);
+                        return;
+                    }
                 }
-                backingField.SetValue(obj, value);
+                throw new MissingMemberException($"The property {obj.GetType()}.{_propertyInfo.Name} does not have a setter nor a backing field ({backingFieldName}).");
             }
         }
     }

--- a/test/LibraryWithPrivateMembers/MiscTestClasses.cs
+++ b/test/LibraryWithPrivateMembers/MiscTestClasses.cs
@@ -135,4 +135,8 @@ namespace LibraryWithPrivateMembers
         internal int InternalGetOnlyInteger { get; }
         private int PrivateGetOnlyInteger { get; }
     }
+
+    public class Qux : Baz
+    {
+    }
 }

--- a/test/ReflectionMagicTests/UnitTest.cs
+++ b/test/ReflectionMagicTests/UnitTest.cs
@@ -1,7 +1,6 @@
 using LibraryWithPrivateMembers;
 using ReflectionMagic;
 using System;
-using System.Linq;
 using System.Reflection;
 using Xunit;
 
@@ -308,6 +307,33 @@ namespace ReflectionMagicTests
             baz.AsDynamic().PrivateGetOnlyInteger = 42;
 
             Assert.Equal(42, baz.GetType().GetProperty("PrivateGetOnlyInteger", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(baz));
+        }
+
+        [Fact]
+        public void TestSettingPublicInheritedGetOnlyProperty()
+        {
+            var qux = new Qux();
+            qux.AsDynamic().PublicGetOnlyInteger = 42;
+
+            Assert.Equal(42, qux.PublicGetOnlyInteger);
+        }
+
+        [Fact]
+        public void TestSettingInternalInheritedGetOnlyProperty()
+        {
+            var qux = new Qux();
+            qux.AsDynamic().InternalGetOnlyInteger = 42;
+
+            Assert.Equal(42, qux.GetType().BaseType?.GetProperty("InternalGetOnlyInteger", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(qux));
+        }
+
+        [Fact]
+        public void TestSettingPrivateInheritedGetOnlyProperty()
+        {
+            var qux = new Qux();
+            qux.AsDynamic().PrivateGetOnlyInteger = 42;
+
+            Assert.Equal(42, qux.GetType().BaseType?.GetProperty("PrivateGetOnlyInteger", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(qux));
         }
     }
 }


### PR DESCRIPTION
Commit 2a237e515412343ac39eba3569959f584f533537 introduced setting the backing field for get-only properties but forgot about inheritance.